### PR TITLE
[WIP]ChatSpace メッセージ送信の非同期化実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,3 +64,5 @@ gem 'devise'
 gem 'carrierwave'
 
 gem 'mini_magick'
+
+gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,6 +117,10 @@ GEM
       ruby-vips (>= 2.0.17, < 3)
     jbuilder (2.10.0)
       activesupport (>= 5.0.0)
+    jquery-rails (4.4.0)
+      rails-dom-testing (>= 1, < 3)
+      railties (>= 4.2.0)
+      thor (>= 0.14, < 2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -263,6 +267,7 @@ DEPENDENCIES
   font-awesome-sass
   haml-rails (>= 1.0, <= 2.0.1)
   jbuilder (~> 2.7)
+  jquery-rails
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,2 +1,3 @@
 //= link_tree ../images
+//= link_directory ../javascripts .js
 //= link_directory ../stylesheets .css

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,0 +1,3 @@
+//= require jquery
+//= require rails-ujs
+//= require_tree .

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -15,7 +15,7 @@ $(function(){
             <p class="Message__content">
               ${message.content}
             </p>
-            <img class="Message__image" src="/uploads/message/image/17/%E3%83%86%E3%83%AC%E3%83%AF%E3%83%BC%E3%83%BC%E3%82%AF.jpeg">
+            <img class="Message__image" src="${message.image}">
           </div>
         </div>`
       return html;

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,66 @@
+$(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      let html = 
+        `<div class="chat-list">
+          <div class="chat-list__box">
+            <p class="chat-list__box__info-user">
+              ${message.user_name}
+            </p>
+            <p class="chat-list__box__info-date">
+              ${message.created_at}
+            </p>
+          </div>
+          <div class="chat-list__message">
+            <p class="Message__content">
+              ${message.content}
+            </p>
+            <img class="Message__image" src="/uploads/message/image/17/%E3%83%86%E3%83%AC%E3%83%AF%E3%83%BC%E3%83%BC%E3%82%AF.jpeg">
+          </div>
+        </div>`
+      return html;
+    } else {
+      let html = 
+        `<div class="chat-list">
+          <div class="chat-list__box">
+            <p class="chat-list__box__info-user">
+              ${message.user_name}
+            </p>
+            <p class="chat-list__box__info-date">
+              ${message.created_at}
+            </p>
+          </div>
+          <div class="chat-list__message">
+            <p class="Message__content">
+              ${message.content}
+            </p>
+          </div>
+        </div>`
+      return html;
+    };
+  }
+
+  $('form').on('submit', function(e){
+    e.preventDefault();
+    let formData = new FormData(this);
+    let url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,  
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+    .done(function(data){
+      let html = buildHTML(data);
+      $('.chat-main').append(html);
+      $('form')[0].reset();
+      $('.chat-main').animate({ scrollTop: $('.chat-main')[0].scrollHeight});
+      $('.submit-btn').prop('disabled', false);
+    })
+    .fail(function(){
+      alert('メッセージ送信に失敗しました');
+    })
+  });
+});

--- a/app/assets/stylesheets/modules/_messages.scss
+++ b/app/assets/stylesheets/modules/_messages.scss
@@ -103,6 +103,7 @@
     height: calc(100vh - 190px);
     width: calc(100vw - 300px); 
     padding: 35px 40px 0;
+    overflow: scroll;
     .chat-list {
       margin-bottom: 46px;
       &__box {

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,7 +9,10 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージを送信しました' }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -5,7 +5,7 @@
     %title ChatSpace
     = csrf_meta_tags
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
-    = javascript_pack_tag 'application', 'data-turbolinks-track': 'reload'
+    = javascript_include_tag 'application'
   %body
     = render 'layouts/notifications'
     = yield

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,4 @@
+json.user_name @message.user.name
+json.created_at @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.content @message.content
+json.image @message.image_url

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,5 +16,6 @@ module ChatSpace
       g.test_framework false
     end
     config.i18n.default_locale = :ja
+    config.time_zone = 'Tokyo'
   end
 end


### PR DESCRIPTION
#what
メッセージ送信の非同期化の実装をする。JavaScriptやjQueryを用いてイベントが発火したときにAjaxを使用してmessages#createが動くようにした。また、respond_toを使用してHTMLとJSONの場合で処理を分けた。
jbuilderを使用して作成したメッセージをJSON形式で返し、返ってきたJSONをdoneメソッドで受取り、HTMLを作成するようにした。その作成したHTMLをメッセージ画面の一番下に追加する仕様にした。
また、メッセージを送信したときメッセージ画面を最下部にスクロールするようにする、連続で送信ボタンを押せるようにする、非同期に失敗した場合の処理も準備にする、などの機能も追加した。 
#why 
非同期通信を実装する事でページを遷移することなくページの一部だけを更新できる。それにより読み込み時間を短縮できるようにするため。