### PR TITLE
インクリメンタルサーチ機能の実装

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -40,7 +40,7 @@ $(function(){
     };
   }
 
-  $('form').on('submit', function(e){
+  $('.form-updata').on('submit', function(e){
     e.preventDefault();
     let formData = new FormData(this);
     let url = $(this).attr('action');
@@ -48,7 +48,7 @@ $(function(){
       url: url,
       type: "POST",
       data: formData,  
-      dataType: 'json',
+      dataType: "json",
       processData: false,
       contentType: false
     })

--- a/app/assets/javascripts/users.js
+++ b/app/assets/javascripts/users.js
@@ -1,0 +1,67 @@
+$(function() {
+  function addUser(user) {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">${user.name}</p>
+                  <div class="ChatMember__add ChatMember__button" data-user-id="${user.id}" data-user-name="${user.name}">追加</div>
+                </div>
+                `;
+    $("#UserSearchResult").append(html);
+  }
+
+  function addNoUser() {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">ユーザーが見つかりません</p>
+                </div>
+                `;
+    $("#UserSearchResult").append(html);
+  }
+
+  function addMember(name, id) {
+    let html = `
+                <div class="ChatMember">
+                  <p class="ChatMember__name">${name}</p>
+                  <input name="group[user_ids][]" type="hidden" value="${id}" />
+                  <div class="ChatMember__remove ChatMember__button">削除</div>
+                </div>
+                `;
+    $(".ChatMembers").append(html);
+  }
+
+  $("#UserSearch__field").on("keyup", function() {
+    let input = $("#UserSearch__field").val();
+    $.ajax({
+      type: "GET",
+      url: "/users",
+      data: { keyword: input },
+      dataType: "json"
+    })
+    .done(function(users) {
+      $("#UserSearchResult").empty();
+      if (users.length !== 0) {
+        users.forEach(function(user) {
+          addUser(user);
+        });
+      } else if (input.length == 0) {
+        return false;
+      } else {
+        addNoUser();
+      }
+    })
+    .fail(function() {
+      alert("ユーザー検索に失敗しました");
+    });
+  });
+  $("#UserSearchResult").on("click", ".ChatMember__add", function() {
+    const userName = $(this).attr("data-user-name");
+    const userId = $(this).attr("data-user-id");
+    $(this)
+      .parent()
+      .remove();
+    addMember(userName, userId);
+  });
+  $(".ChatMembers").on("click", ".ChatMember__remove", function() {
+    $(this).parent().remove();
+  });
+});

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -11,6 +11,15 @@ class UsersController < ApplicationController
     end
   end
 
+  def index
+    return nil if params[:keyword] == ""
+    @users = User.where(['name LIKE ?', "%#{params[:keyword]}%"] ).where.not(id: current_user.id).limit(10)
+    respond_to do |format|
+      format.html
+      format.json
+    end
+  end
+
   private
 
   def user_params

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,8 +1,10 @@
 = form_with model: group, local: true do |f|
-  .SettingGroupForm__errors
-    %h2 10件のエラーが発生しました
-    %ul
-      %li nameを入力してください
+  - if group.errors.any?
+    .SettingGroupForm__errors
+      %h2= "#{group.errors.full_messages.count}件のエラーが発生しました。"
+      %ul
+        - group.errors.full_messages.each do |message|
+          %li= message
   .SettingGroupForm__field
     .SettingGroupForm__leftField
       = f.label :name, "グループ名", class: 'SettingGroupForm__label'
@@ -12,9 +14,24 @@
     .SettingGroupForm__leftField
       %label.SettingGroupForm__label チャットメンバーを追加
     .SettingGroupForm__rightField
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      = f.collection_check_boxes :user_ids, User.all, :id, :name
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
+      .UserSearch
+        %input#UserSearch__field.SettingGroupForm__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
+      #UserSearchResult
+  .SettingGroupForm__field
+    .SettingGroupForm__leftField
+      = f.label :name, value: "チャットメンバー", class: "SettingGroupForm__label"
+    .SettingGroupForm__rightField
+      .ChatMembers
+        .ChatMember
+          %p.ChatMember__name= current_user.name
+          %input{name: "group[user_ids][]", type: "hidden", value: current_user.id}
+        - group.users.each do |user|
+          - if current_user.name != user.name
+            .ChatMember
+              %p.ChatMember__name 
+                = user.name
+              .ChatMember__remove.ChatMember__button{"data-user-id": user.id, "data-user-name": user.name} 削除
+              %input{name: "group[user_ids][]", type:"hidden", value: user.id}
   .SettingGroupForm__field
     .SettingGroupForm__leftField
     .SettingGroupForm__rightField

--- a/app/views/messages/_main_chat.html.haml
+++ b/app/views/messages/_main_chat.html.haml
@@ -14,7 +14,7 @@
     = render @messages
 
   .form
-    = form_with model: [@group, @message], local: true do |f|
+    = form_with model: [@group, @message], class: "form-updata",local: true do |f|
       .form-box
         .new-message
           = f.text_field :content, class: 'input-box__text', placeholder: 'type a message'

--- a/app/views/users/index.json.jbuilder
+++ b/app/views/users/index.json.jbuilder
@@ -1,0 +1,4 @@
+json.array! @users do |user|
+  json.id user.id
+  json.name user.name
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root 'groups#index'
-  resources :users, only: [:edit, :update]
+  resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end


### PR DESCRIPTION
#what
ユーザーがインクリメンタルサーチされるように実装する。
グループ編集にてユーザー追加ボタンを押した時にイベントが発火するようにする。
チャットメンバーの部分に追加されたユーザーの名前を追加し、検索結果からは消すようにする。
削除を押すと、チャットメンバーから削除されるようにする。
編集画面では既存のユーザーが追加済みの状態である事を確認する。
users.jsファイルを作成し、それに伴うコントローラー、ルーティングの設定を編集した。

#why
インクリメンタルサーチを実装する事により、わざわざ検索機能を押さなくても良くなり、訪問者にとって使いやすいページにする事が出来る。